### PR TITLE
 There were issues with protocol witness table linking during archivi…

### DIFF
--- a/EtherKit/Models/Address.swift
+++ b/EtherKit/Models/Address.swift
@@ -9,11 +9,11 @@ import CryptoSwift
 import secp256k1
 
 public struct Address: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .constrained(20)
   }
 
-  let data: Data
+  public let data: Data
 
   // EIP55: Mixed-case checksum address encoding:
   // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
@@ -35,11 +35,11 @@ public struct Address: UnformattedDataType {
     return "0x\(address)"
   }
 
-  init(data: Data) {
+  public init(data: Data) {
     self.data = data
   }
 
-  init(from publicKey: Data) {
+  public init(from publicKey: Data) {
     self.init(data: publicKey.sha3(.keccak256)[12 ..< 32])
   }
 }

--- a/EtherKit/Models/BloomFilter.swift
+++ b/EtherKit/Models/BloomFilter.swift
@@ -6,9 +6,13 @@
 //
 
 public struct BloomFilter: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .constrained(256)
   }
 
   public let data: Data
+
+  public init(data: Data) {
+    self.data = data
+  }
 }

--- a/EtherKit/Models/GeneralData.swift
+++ b/EtherKit/Models/GeneralData.swift
@@ -6,7 +6,7 @@
 //
 
 public struct GeneralData: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .unlimited
   }
 

--- a/EtherKit/Models/Hash.swift
+++ b/EtherKit/Models/Hash.swift
@@ -6,9 +6,13 @@
 //
 
 public struct Hash: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .constrained(32)
   }
 
-  let data: Data
+  public let data: Data
+
+  public init(data: Data) {
+    self.data = data
+  }
 }

--- a/EtherKit/Models/Nonce.swift
+++ b/EtherKit/Models/Nonce.swift
@@ -6,9 +6,13 @@
 //
 
 public struct Nonce: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .constrained(8)
   }
 
   public let data: Data
+
+  public init(data: Data) {
+    self.data = data
+  }
 }

--- a/EtherKit/Models/UnformattedDataType.swift
+++ b/EtherKit/Models/UnformattedDataType.swift
@@ -12,7 +12,7 @@ public enum UnformattedDataMode {
   case unlimited
 }
 
-protocol UnformattedDataType: CustomStringConvertible, ValueType, RLPValueType, Hashable, Codable {
+public protocol UnformattedDataType: CustomStringConvertible, ValueType, RLPValueType, Hashable, Codable {
   static var byteCount: UnformattedDataMode { get }
   static func value(from data: Data) throws -> Self
 

--- a/EtherKit/RLP.swift
+++ b/EtherKit/RLP.swift
@@ -8,7 +8,7 @@
 import BigInt
 
 public struct RLPData: UnformattedDataType {
-  static var byteCount: UnformattedDataMode {
+  public static var byteCount: UnformattedDataMode {
     return .unlimited
   }
 
@@ -17,6 +17,10 @@ public struct RLPData: UnformattedDataType {
   }
 
   public let data: Data
+
+  public init(data: Data) {
+    self.data = data
+  }
 }
 
 public protocol RLPValueType {

--- a/Example/EtherKit/ViewController.swift
+++ b/Example/EtherKit/ViewController.swift
@@ -8,8 +8,8 @@
 
 import BigInt
 import EtherKit
-import UIKit
 import PromiseKit
+import UIKit
 
 class ViewController: UIViewController {
   // Keep one reference to EtherKit per app.
@@ -20,12 +20,13 @@ class ViewController: UIViewController {
       applicationTag: "io.vault.etherkit.example"
     )
   }()
-  
+
   private var generatedAddress: Address! {
     didSet {
       addressField.text = String(describing: generatedAddress!)
     }
   }
+
   private var toAddress: Address!
 
   @IBOutlet var addressField: UITextField!
@@ -33,7 +34,7 @@ class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     firstly {
       when(fulfilled: etherKit.createKeyPair(.promise), etherKit.createKeyPair(.promise))
     }.done { address1, address2 in

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,17 +2,17 @@ PODS:
   - BigInt (3.0.1):
     - SipHash (~> 1.2)
   - CryptoSwift (0.9.0)
-  - EtherKit (0.1.1):
-    - EtherKit/Core (= 0.1.1)
-    - EtherKit/PromiseKit (= 0.1.1)
-  - EtherKit/Core (0.1.1):
+  - EtherKit (0.1.2):
+    - EtherKit/Core (= 0.1.2)
+    - EtherKit/PromiseKit (= 0.1.2)
+  - EtherKit/Core (0.1.2):
     - BigInt
     - CryptoSwift
     - Marshal
     - Result (~> 4.0.0)
     - secp256k1.swift
     - Starscream
-  - EtherKit/PromiseKit (0.1.1):
+  - EtherKit/PromiseKit (0.1.2):
     - EtherKit/Core
     - PromiseKit/CorePromise
   - Marshal (1.2.4)
@@ -46,7 +46,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BigInt: 8e8a52161c745cd3ab78e3dc346a9fbee51e6cf6
   CryptoSwift: bca8c5b653dcc2d9734409242a070ff53bafac86
-  EtherKit: 1c3ede4bf7d02e6e8f464d79389a61a71e7e5294
+  EtherKit: ce38ebadf011643dfd1425ac8a8dc47008a7fdd5
   Marshal: 8e04e6624e506921db7143b0bfd83caee03f32d6
   PromiseKit: a26828b0a8d5874960dfdb575b57a70790ec36f1
   Result: 7645bb3f50c2ce726dd0ff2fa7b6f42bbe6c3713


### PR DESCRIPTION
…ng for Vault, so I fixed it by making the UnformattedDataType public.

I would prefer for the `UnformattedDataType.init(data:)` to remain non-public, it doesn't do validation that the data matches the byte requirements, and it's difficult to do so as `data` is a stored property on structs that implement `UnformattedDataType`. I'm sure there's a way to pull this off without resulting in use of associated objects (which would require a movement to use classes to force compatibility with `NSObject`), but I'm not sure how right now.