### PR TITLE
 Add GetTransactionByHash request, cleanup some features

### DIFF
--- a/EtherKit/EtherKeyManager.swift
+++ b/EtherKit/EtherKeyManager.swift
@@ -156,7 +156,7 @@ public final class EtherKeyManager {
       completion(.success(newAddress))
     }
   }
-  
+
   // MARK: Internal API
 
   private func mapToCryptoKey(for address: Address, block: @escaping (_ privateKey: [UInt8]) throws -> Void) throws {
@@ -199,7 +199,7 @@ public final class EtherKeyManager {
 
     try block([UInt8](decryptedCryptoKey as! Data))
   }
-  
+
   func signRaw(
     _ data: Data,
     for address: Address,
@@ -207,7 +207,7 @@ public final class EtherKeyManager {
   ) throws {
     var digestForData = [UInt8](data.sha3(.keccak256))
     var unsafeSignature = secp256k1_ecdsa_recoverable_signature.init()
-    
+
     try mapToCryptoKey(for: address) { privateKey throws in
       let result = secp256k1_ecdsa_sign_recoverable(
         self.secp256k1Context,
@@ -220,7 +220,7 @@ public final class EtherKeyManager {
       guard result == 1 else {
         throw EtherKitError.keyManagerFailed(reason: .signatureFailed)
       }
-      
+
       let signatureBytesPtr: UnsafeMutablePointer<UInt8> = UnsafeMutablePointer.allocate(capacity: 64)
       var recoveryID: Int32 = 0
       secp256k1_ecdsa_recoverable_signature_serialize_compact(
@@ -230,11 +230,11 @@ public final class EtherKeyManager {
         &unsafeSignature
       )
       let signatureBytes: [UInt8] = (0 ..< Int(64)).map { return signatureBytesPtr[$0] }
-      
+
       callback(Data(bytes: signatureBytes), UInt(recoveryID))
     }
   }
-  
+
   func verifyRaw(
     _ signature: Data,
     address: Address,
@@ -245,11 +245,11 @@ public final class EtherKeyManager {
       var privateKey = privateKey
       var publicKey = secp256k1_pubkey.init()
       secp256k1_ec_pubkey_create(self.secp256k1Context, &publicKey, &privateKey)
-      
+
       var signatureBytes = [UInt8](signature)
       var signature = secp256k1_ecdsa_signature.init()
       secp256k1_ecdsa_signature_parse_compact(self.secp256k1Context, &signature, &signatureBytes)
-      
+
       var digestBytes = [UInt8](digest)
       let validateResult = secp256k1_ecdsa_verify(self.secp256k1Context, &signature, &digestBytes, &publicKey)
       callback(validateResult == 1)

--- a/EtherKit/EtherQuery.swift
+++ b/EtherKit/EtherQuery.swift
@@ -55,6 +55,13 @@ public final class EtherQuery {
   public func blockNumber() -> BlockNumberRequest {
     return BlockNumberRequest()
   }
+  
+  public func block(_ blockNumber: BlockNumber, fullTransactionObjects: Bool = false) -> GetBlockByNumberRequest {
+    return GetBlockByNumberRequest(GetBlockByNumberRequest.Parameters(
+      blockNumber: blockNumber,
+      fullTransactionObjects: fullTransactionObjects
+    ))
+  }
 
   public func gasPrice() -> GasPriceRequest {
     return GasPriceRequest()

--- a/EtherKit/EtherQuery.swift
+++ b/EtherKit/EtherQuery.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import Result
 import Marshal
+import Result
 
 public final class EtherQuery {
   public enum ConnectionMode {
@@ -16,46 +16,52 @@ public final class EtherQuery {
   }
 
   private let connectionMode: ConnectionMode
+  private let extraRequestHeaders: [String: String]?
   private let url: URL
-  
+
   private lazy var manager: RequestManager = {
     switch connectionMode {
     case .http:
-      return URLRequestManager(for: url)
+      return URLRequestManager(for: url, extraRequestHeaders: extraRequestHeaders)
     case .websocket:
-      return WebSocketManager(for: url)
+      return WebSocketManager(for: url, extraRequestHeaders: extraRequestHeaders)
     }
   }()
-  
-  public init(_ url: URL, connectionMode: ConnectionMode) {
+
+  public init(_ url: URL, connectionMode: ConnectionMode, extraRequestHeaders: [String: String]? = nil) {
     self.url = url
     self.connectionMode = connectionMode
+    self.extraRequestHeaders = extraRequestHeaders
   }
-  
+
   // MARK: JSONRPC Request Implementations
-  
+
   public func networkVersion() -> NetVersionRequest {
     return NetVersionRequest()
   }
-  
+
   public func balanceOf(_ address: Address, blockNumber: BlockNumber = .latest) -> GetBalanceRequest {
     return GetBalanceRequest(GetBalanceRequest.Parameters(address: address, blockNumber: blockNumber))
   }
-  
+
   public func transactionCount(_ address: Address, blockNumber: BlockNumber = .latest) -> GetTransactionCountRequest {
     return GetTransactionCountRequest(GetTransactionCountRequest.Parameters(address: address, blockNumber: blockNumber))
   }
-  
+
+  public func transaction(_ hash: Hash) -> GetTransactionByHashRequest {
+    return GetTransactionByHashRequest(GetTransactionByHashRequest.Parameters(hash: hash))
+  }
+
   public func blockNumber() -> BlockNumberRequest {
     return BlockNumberRequest()
   }
-  
+
   public func gasPrice() -> GasPriceRequest {
     return GasPriceRequest()
   }
-  
+
   // MARK: Request Dispatchers
-  
+
   public func request<T: Request>(
     _ request: T,
     completion: @escaping (Result<T.Result, EtherKitError>) -> Void
@@ -64,7 +70,7 @@ public final class EtherQuery {
       completion(.failure(EtherKitError.jsonRPCFailed(reason: .invalidRequestJSON)))
       return
     }
-    
+
     manager.queueRequest(
       .single(request.id),
       request: requestAsDatum
@@ -78,7 +84,7 @@ public final class EtherQuery {
       }
     }
   }
-  
+
   public func request<T1: Request, T2: Request>(
     _ request1: T1,
     _ request2: T2,
@@ -86,11 +92,11 @@ public final class EtherQuery {
   ) {
     guard let requestsAsData = try? JSONSerialization.data(
       withJSONObject: [request1.marshaled(), request2.marshaled()]
-      ) else {
-        completion(.failure(.jsonRPCFailed(reason: .invalidRequestJSON)))
-        return
+    ) else {
+      completion(.failure(.jsonRPCFailed(reason: .invalidRequestJSON)))
+      return
     }
-    
+
     manager.queueRequest(
       .batch([request1.id, request2.id]),
       request: requestsAsData
@@ -100,7 +106,7 @@ public final class EtherQuery {
         completion(.failure(.jsonRPCFailed(reason: .parseError(error: marshalError))))
         return
       }
-      
+
       let result1 = responses.compactMap { try? request1.response(from: $0) }.first
       let result2 = responses.compactMap { try? request2.response(from: $0) }.first
       guard result1 != nil && result2 != nil else {
@@ -110,7 +116,7 @@ public final class EtherQuery {
       completion(.success((result1!, result2!)))
     }
   }
-  
+
   public func request<T1: Request, T2: Request, T3: Request>(
     _ request1: T1,
     _ request2: T2,
@@ -119,11 +125,11 @@ public final class EtherQuery {
   ) {
     guard let requestsAsData = try? JSONSerialization.data(
       withJSONObject: [request1.marshaled(), request2.marshaled(), request3.marshaled()]
-      ) else {
-        completion(.failure(.jsonRPCFailed(reason: .invalidRequestJSON)))
-        return
+    ) else {
+      completion(.failure(.jsonRPCFailed(reason: .invalidRequestJSON)))
+      return
     }
-    
+
     manager.queueRequest(
       .batch([request1.id, request2.id, request3.id]),
       request: requestsAsData
@@ -133,7 +139,7 @@ public final class EtherQuery {
         completion(.failure(.jsonRPCFailed(reason: .parseError(error: marshalError))))
         return
       }
-      
+
       let result1 = responses.compactMap { try? request1.response(from: $0) }.first
       let result2 = responses.compactMap { try? request2.response(from: $0) }.first
       let result3 = responses.compactMap { try? request3.response(from: $0) }.first
@@ -144,9 +150,9 @@ public final class EtherQuery {
       completion(.success((result1!, result2!, result3!)))
     }
   }
-  
+
   // MARK: Mutative Requests
-  
+
   public func send(
     using manager: EtherKeyManager,
     from: Address,
@@ -158,7 +164,7 @@ public final class EtherQuery {
     request(
       networkVersion(),
       transactionCount(from, blockNumber: .pending),
-      self.gasPrice()
+      gasPrice()
     ) { result in
       switch result {
       case let .failure(error):
@@ -174,7 +180,7 @@ public final class EtherQuery {
           nonce: nonce,
           data: data ?? GeneralData(data: Data())
         )
-          
+
         transaction.sign(using: manager, with: from, network: network) { result in
           switch result {
           case let .failure(error):

--- a/EtherKit/JSONRPC/Request.swift
+++ b/EtherKit/JSONRPC/Request.swift
@@ -32,7 +32,7 @@ public protocol Request: AnyObject, Marshaling {
   var parameters: Parameters { get }
   var id: String? { get }
 
-  func result(from result: Any) throws -> Result
+  func result(from result: Any?) throws -> Result
   func response(from response: Any) throws -> Result
 }
 
@@ -120,8 +120,11 @@ extension Request where Result: ValueType {
     }
   }
 
-  public func result(from result: Any) throws -> Result.Value {
-    return try Result.value(from: result)
+  public func result(from result: Any?) throws -> Result.Value {
+    guard let nonNullableResult = result else {
+      throw MarshalError.typeMismatch(expected: Any.self, actual: type(of: result))
+    }
+    return try Result.value(from: nonNullableResult)
   }
 }
 

--- a/EtherKit/Models/Block.swift
+++ b/EtherKit/Models/Block.swift
@@ -7,13 +7,13 @@
 
 import Marshal
 
-enum BlockTransactions {
+public enum BlockTransactions {
   case hashes([Hash])
   case transactions([Transaction])
 }
 
 extension BlockTransactions: ValueType {
-  static func value(from object: Any) throws -> BlockTransactions {
+  public static func value(from object: Any) throws -> BlockTransactions {
     if let valueAsHash = object as? [String] {
       return try .hashes(valueAsHash.map { try Hash(describing: $0) })
     }
@@ -31,7 +31,7 @@ extension BlockTransactions: ValueType {
 extension BlockTransactions: RawRepresentable {
   public typealias RawValue = [Any]
 
-  init?(rawValue: [Any]) {
+  public init?(rawValue: [Any]) {
     if let valueAsHash = rawValue as? [String] {
       guard let hashes = try? valueAsHash.map(Hash.value) else {
         return nil
@@ -45,7 +45,7 @@ extension BlockTransactions: RawRepresentable {
     self = .transactions(transactions)
   }
 
-  var rawValue: [Any] {
+  public var rawValue: [Any] {
     switch self {
     case let .hashes(hashes):
       return hashes.map { String(describing: $0) }
@@ -56,25 +56,25 @@ extension BlockTransactions: RawRepresentable {
 }
 
 public struct Block: Unmarshaling, Marshaling {
-  let number: UInt256
-  let hash: Hash
-  let parentHash: Hash
-  let nonce: Nonce
-  let sha3Uncles: Hash
-  let logsBloom: BloomFilter
-  let transactionsRoot: Hash
-  let stateRoot: Hash
-  let receiptsRoot: Hash
-  let miner: Address
-  let difficulty: UInt256
-  let totalDifficulty: UInt256
-  let extraData: GeneralData
-  let size: UInt256
-  let gasLimit: UInt256
-  let gasUsed: UInt256
-  let timestamp: UInt256
-  let uncles: [Hash]
-  let transactions: BlockTransactions
+  public let number: UInt256?
+  public let hash: Hash?
+  public let parentHash: Hash
+  public let nonce: Nonce?
+  public let sha3Uncles: Hash
+  public let logsBloom: BloomFilter?
+  public let transactionsRoot: Hash
+  public let stateRoot: Hash
+  public let receiptsRoot: Hash
+  public let miner: Address
+  public let difficulty: UInt256
+  public let totalDifficulty: UInt256
+  public let extraData: GeneralData
+  public let size: UInt256
+  public let gasLimit: UInt256
+  public let gasUsed: UInt256
+  public let timestamp: UInt256
+  public let uncles: [Hash]
+  public let transactions: BlockTransactions
 
   public init(object: MarshaledObject) throws {
     number = try object.value(for: "number")

--- a/EtherKit/Models/SendTransaction.swift
+++ b/EtherKit/Models/SendTransaction.swift
@@ -8,7 +8,6 @@
 import Marshal
 
 public struct SendTransaction {
-
   public let value: UInt256
   public let to: Address
   public let data: GeneralData
@@ -47,7 +46,7 @@ extension SendTransaction: Marshaling {
       "gasLimit": gasLimit,
       "gasPrice": gasPrice,
       "value": value,
-      "data": data
+      "data": data,
     ].mapValues { String(describing: $0) }
   }
 }
@@ -57,7 +56,7 @@ extension SendTransaction: Signable {
     guard let network = network else {
       return RLPData.encode(from: toRLPValue()).data
     }
-    
+
     return RLPData.encode(
       from: toRLPValue() + Signature(v: network.rawValue, r: 0.packedData, s: 0.packedData).toRLPValue()
     ).data

--- a/EtherKit/Models/Signature.swift
+++ b/EtherKit/Models/Signature.swift
@@ -6,12 +6,12 @@
 //
 
 import BigInt
-import Result
 import Marshal
+import Result
 
 public protocol Signable {
   func signatureData(_ network: Network?) -> Data
-  
+
   func sign(
     using manager: EtherKeyManager,
     with address: Address,
@@ -71,7 +71,7 @@ public struct Signature: Marshaling, RLPComplexType, CustomStringConvertible {
   public var v: UInt
   public var r: Data
   public var s: Data
-  
+
   public init(v: UInt, r: Data, s: Data) {
     self.v = v
     self.r = r
@@ -92,9 +92,9 @@ public struct Signature: Marshaling, RLPComplexType, CustomStringConvertible {
     let sigData = r + s + v.packedData
     return sigData.paddedHexString
   }
-  
+
   // MARK: - RLPComplexType
-  
+
   public func toRLPValue() -> [RLPValueType] {
     return [v, r, s]
   }

--- a/EtherKit/Models/Transaction.swift
+++ b/EtherKit/Models/Transaction.swift
@@ -11,7 +11,7 @@ public struct Transaction {
   let hash: Hash
   let nonce: UInt256
   let blockHash: Hash
-  let blockNumber: UInt256
+  let blockNumber: UInt256?
   let transactionIndex: UInt256?
   let from: Address
   let to: Address

--- a/EtherKit/Models/Transaction.swift
+++ b/EtherKit/Models/Transaction.swift
@@ -8,17 +8,17 @@
 import Marshal
 
 public struct Transaction {
-  let hash: Hash
-  let nonce: UInt256
-  let blockHash: Hash
-  let blockNumber: UInt256?
-  let transactionIndex: UInt256?
-  let from: Address
-  let to: Address
-  let value: UInt256
-  let gasPrice: UInt256
-  let gas: UInt256
-  let input: GeneralData
+  public let hash: Hash
+  public let nonce: UInt256
+  public let blockHash: Hash
+  public let blockNumber: UInt256?
+  public let transactionIndex: UInt256?
+  public let from: Address
+  public let to: Address
+  public let value: UInt256
+  public let gasPrice: UInt256
+  public let gas: UInt256
+  public let input: GeneralData
 }
 
 extension Transaction: Unmarshaling {

--- a/EtherKit/Models/UInt256.swift
+++ b/EtherKit/Models/UInt256.swift
@@ -8,7 +8,7 @@
 import BigInt
 import Marshal
 
-public struct UInt256 {
+public struct UInt256: Equatable {
   public let describing: BigUInt
 
   public init(_ value: BigUInt) {

--- a/EtherKit/RequestProtocols/URLRequestManager.swift
+++ b/EtherKit/RequestProtocols/URLRequestManager.swift
@@ -9,9 +9,11 @@ final class URLRequestManager: RequestManager {
   let url: URL
 
   private var pendingRequests = [RequestIDKey: URLSessionDataTask]()
+  private var extraRequestHeaders: [String: String]?
 
-  init(for url: URL) {
+  init(for url: URL, extraRequestHeaders: [String: String]? = nil) {
     self.url = url
+    self.extraRequestHeaders = extraRequestHeaders
   }
 
   func queueRequest(_ key: RequestIDKey, request: String, callback: @escaping (Any) -> Void) {
@@ -19,6 +21,8 @@ final class URLRequestManager: RequestManager {
     pendingRequests.removeValue(forKey: key)
 
     var urlRequest = URLRequest(url: url)
+    extraRequestHeaders?.forEach { header, value in urlRequest.setValue(value, forHTTPHeaderField: header) }
+
     urlRequest.httpMethod = "POST"
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
     urlRequest.httpBody = request.data(using: .utf8)

--- a/EtherKit/Requests/GasPriceRequest.swift
+++ b/EtherKit/Requests/GasPriceRequest.swift
@@ -8,7 +8,7 @@
 public class GasPriceRequest: Request {
   public typealias Parameters = Void
   public typealias Result = UInt256
-  
+
   public var method: String {
     return "eth_gasPrice"
   }

--- a/EtherKit/Requests/GetBlockByNumberRequest.swift
+++ b/EtherKit/Requests/GetBlockByNumberRequest.swift
@@ -1,5 +1,5 @@
 //
-//  GetTransactionByHashRequest.swift
+//  GetBlockByNumberRequest.swift
 //  EtherKit
 //
 //  Created by Cole Potrocky on 6/12/18.
@@ -7,24 +7,28 @@
 
 import Marshal
 
-public class GetTransactionByHashRequest: Request {
+public class GetBlockByNumberRequest: Request {
   public struct Parameters: Marshaling {
-    let hash: Hash
-
+    let blockNumber: BlockNumber
+    let fullTransactionObjects: Bool
+    
     // MARK: - Marshaling
-
+    
     public func marshaled() -> [Any] {
-      return [String(describing: hash)]
+      return [blockNumber.rawValue, fullTransactionObjects]
     }
   }
-
-  public typealias Result = Transaction
+  
+  public typealias Result = Block
+  
   public var parameters: Parameters
+  
   public var method: String {
-    return "eth_getTransactionByHash"
+    return "eth_getBlockByNumber"
   }
-
+  
   init(_ parameters: Parameters) {
     self.parameters = parameters
   }
 }
+

--- a/EtherKit/Requests/GetTransactionByHashRequest.swift
+++ b/EtherKit/Requests/GetTransactionByHashRequest.swift
@@ -1,0 +1,30 @@
+//
+//  GetTransactionByHashRequest.swift
+//  EtherKit
+//
+//  Created by Cole Potrocky on 6/12/18.
+//
+
+import Marshal
+
+public class GetTransactionByHashRequest: Request {
+  public struct Parameters: Marshaling {
+    let hash: Hash
+
+    // MARK: - Marshaling
+
+    public func marshaled() -> [Any] {
+      return [hash]
+    }
+  }
+
+  public typealias Result = Transaction
+  public var parameters: Parameters
+  public var method: String {
+    return "eth_getTransactionByHash"
+  }
+
+  init(_ parameters: Parameters) {
+    self.parameters = parameters
+  }
+}

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - BigInt (3.0.1):
+  - BigInt (3.1.0):
     - SipHash (~> 1.2)
-  - CryptoSwift (0.9.0)
+  - CryptoSwift (0.10.0)
   - EtherKit (0.1.4):
     - EtherKit/Core (= 0.1.4)
     - EtherKit/PromiseKit (= 0.1.4)
@@ -16,10 +16,10 @@ PODS:
     - EtherKit/Core
     - PromiseKit/CorePromise
   - Marshal (1.2.4)
-  - PromiseKit/CorePromise (6.2.5)
+  - PromiseKit/CorePromise (6.3.0)
   - Result (4.0.0)
   - secp256k1.swift (0.1.4)
-  - SipHash (1.2.0)
+  - SipHash (1.2.2)
   - Starscream (3.0.5)
   - SwiftCheck (0.10.0)
 
@@ -44,14 +44,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BigInt: 8e8a52161c745cd3ab78e3dc346a9fbee51e6cf6
-  CryptoSwift: bca8c5b653dcc2d9734409242a070ff53bafac86
+  BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
+  CryptoSwift: 6c778d69282bed3b4e975ff97a79d074f20bb011
   EtherKit: 57c8db3feb9f643d9060f83439b00fdd99117c8a
   Marshal: 8e04e6624e506921db7143b0bfd83caee03f32d6
-  PromiseKit: a26828b0a8d5874960dfdb575b57a70790ec36f1
+  PromiseKit: cf84bbb1235a61473b326c5cf0b41f6828f87ba5
   Result: 7645bb3f50c2ce726dd0ff2fa7b6f42bbe6c3713
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
-  SipHash: c6e9e43e9c531b5bc6602545130c26194a6d31ce
+  SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
   SwiftCheck: 8a3c3638941467bc142d625f374a8409dd262ae8
 


### PR DESCRIPTION
 Full changelog:

 * Added a param to set HTTP headers for requests.  This allows, for example,
   basic HTTP Auth to be used.
 * Upgraded all used pods.
 * Added GetTransacitonByHash request.
 * Updated `Transaction` to be up-to-spec: blockNumber can be null if it's still pending (i.e. still be transmitted).
 * Ensured that we still flush websocket requests that are pending if the socket is connected.