### PR TITLE
Cleaned up some parsing/visibility bugs, added GetBlockByNumber request

### DIFF
--- a/EtherKit/EtherQuery.swift
+++ b/EtherKit/EtherQuery.swift
@@ -55,6 +55,13 @@ public final class EtherQuery {
   public func blockNumber() -> BlockNumberRequest {
     return BlockNumberRequest()
   }
+  
+  public func block(_ blockNumber: BlockNumber, fullTransactionObjects: Bool = false) -> GetBlockByNumberRequest {
+    return GetBlockByNumberRequest(GetBlockByNumberRequest.Parameters(
+      blockNumber: blockNumber,
+      fullTransactionObjects: fullTransactionObjects
+    ))
+  }
 
   public func gasPrice() -> GasPriceRequest {
     return GasPriceRequest()

--- a/EtherKit/JSONRPC/Request.swift
+++ b/EtherKit/JSONRPC/Request.swift
@@ -32,7 +32,7 @@ public protocol Request: AnyObject, Marshaling {
   var parameters: Parameters { get }
   var id: String? { get }
 
-  func result(from result: Any) throws -> Result
+  func result(from result: Any?) throws -> Result
   func response(from response: Any) throws -> Result
 }
 
@@ -120,8 +120,11 @@ extension Request where Result: ValueType {
     }
   }
 
-  public func result(from result: Any) throws -> Result.Value {
-    return try Result.value(from: result)
+  public func result(from result: Any?) throws -> Result.Value {
+    guard let nonNullableResult = result else {
+      throw MarshalError.typeMismatch(expected: Any.self, actual: type(of: result))
+    }
+    return try Result.value(from: nonNullableResult)
   }
 }
 
@@ -131,7 +134,7 @@ extension Request where Result == Void {
     return nil
   }
 
-  func response(from _: Any) throws -> Result {
+  func response(from _: Any?) throws -> Result {
     return ()
   }
 }

--- a/EtherKit/JSONRPC/Request.swift
+++ b/EtherKit/JSONRPC/Request.swift
@@ -134,7 +134,7 @@ extension Request where Result == Void {
     return nil
   }
 
-  func response(from _: Any?) throws -> Result {
+  func response(from _: Any) throws -> Result {
     return ()
   }
 }

--- a/EtherKit/Models/Block.swift
+++ b/EtherKit/Models/Block.swift
@@ -7,13 +7,13 @@
 
 import Marshal
 
-enum BlockTransactions {
+public enum BlockTransactions {
   case hashes([Hash])
   case transactions([Transaction])
 }
 
 extension BlockTransactions: ValueType {
-  static func value(from object: Any) throws -> BlockTransactions {
+  public static func value(from object: Any) throws -> BlockTransactions {
     if let valueAsHash = object as? [String] {
       return try .hashes(valueAsHash.map { try Hash(describing: $0) })
     }
@@ -31,7 +31,7 @@ extension BlockTransactions: ValueType {
 extension BlockTransactions: RawRepresentable {
   public typealias RawValue = [Any]
 
-  init?(rawValue: [Any]) {
+  public init?(rawValue: [Any]) {
     if let valueAsHash = rawValue as? [String] {
       guard let hashes = try? valueAsHash.map(Hash.value) else {
         return nil
@@ -45,7 +45,7 @@ extension BlockTransactions: RawRepresentable {
     self = .transactions(transactions)
   }
 
-  var rawValue: [Any] {
+  public var rawValue: [Any] {
     switch self {
     case let .hashes(hashes):
       return hashes.map { String(describing: $0) }
@@ -56,25 +56,25 @@ extension BlockTransactions: RawRepresentable {
 }
 
 public struct Block: Unmarshaling, Marshaling {
-  let number: UInt256
-  let hash: Hash
-  let parentHash: Hash
-  let nonce: Nonce
-  let sha3Uncles: Hash
-  let logsBloom: BloomFilter
-  let transactionsRoot: Hash
-  let stateRoot: Hash
-  let receiptsRoot: Hash
-  let miner: Address
-  let difficulty: UInt256
-  let totalDifficulty: UInt256
-  let extraData: GeneralData
-  let size: UInt256
-  let gasLimit: UInt256
-  let gasUsed: UInt256
-  let timestamp: UInt256
-  let uncles: [Hash]
-  let transactions: BlockTransactions
+  public let number: UInt256?
+  public let hash: Hash?
+  public let parentHash: Hash
+  public let nonce: Nonce?
+  public let sha3Uncles: Hash
+  public let logsBloom: BloomFilter?
+  public let transactionsRoot: Hash
+  public let stateRoot: Hash
+  public let receiptsRoot: Hash
+  public let miner: Address
+  public let difficulty: UInt256
+  public let totalDifficulty: UInt256
+  public let extraData: GeneralData
+  public let size: UInt256
+  public let gasLimit: UInt256
+  public let gasUsed: UInt256
+  public let timestamp: UInt256
+  public let uncles: [Hash]
+  public let transactions: BlockTransactions
 
   public init(object: MarshaledObject) throws {
     number = try object.value(for: "number")

--- a/EtherKit/Models/Transaction.swift
+++ b/EtherKit/Models/Transaction.swift
@@ -8,17 +8,17 @@
 import Marshal
 
 public struct Transaction {
-  let hash: Hash
-  let nonce: UInt256
-  let blockHash: Hash
-  let blockNumber: UInt256?
-  let transactionIndex: UInt256?
-  let from: Address
-  let to: Address
-  let value: UInt256
-  let gasPrice: UInt256
-  let gas: UInt256
-  let input: GeneralData
+  public let hash: Hash
+  public let nonce: UInt256
+  public let blockHash: Hash
+  public let blockNumber: UInt256?
+  public let transactionIndex: UInt256?
+  public let from: Address
+  public let to: Address
+  public let value: UInt256
+  public let gasPrice: UInt256
+  public let gas: UInt256
+  public let input: GeneralData
 }
 
 extension Transaction: Unmarshaling {

--- a/EtherKit/Models/UInt256.swift
+++ b/EtherKit/Models/UInt256.swift
@@ -8,7 +8,7 @@
 import BigInt
 import Marshal
 
-public struct UInt256 {
+public struct UInt256: Equatable {
   public let describing: BigUInt
 
   public init(_ value: BigUInt) {

--- a/EtherKit/Requests/GetBlockByNumberRequest.swift
+++ b/EtherKit/Requests/GetBlockByNumberRequest.swift
@@ -1,5 +1,5 @@
 //
-//  GetTransactionByHashRequest.swift
+//  GetBlockByNumberRequest.swift
 //  EtherKit
 //
 //  Created by Cole Potrocky on 6/12/18.
@@ -7,24 +7,28 @@
 
 import Marshal
 
-public class GetTransactionByHashRequest: Request {
+public class GetBlockByNumberRequest: Request {
   public struct Parameters: Marshaling {
-    let hash: Hash
-
+    let blockNumber: BlockNumber
+    let fullTransactionObjects: Bool
+    
     // MARK: - Marshaling
-
+    
     public func marshaled() -> [Any] {
-      return [String(describing: hash)]
+      return [blockNumber.rawValue, fullTransactionObjects]
     }
   }
-
-  public typealias Result = Transaction
+  
+  public typealias Result = Block
+  
   public var parameters: Parameters
+  
   public var method: String {
-    return "eth_getTransactionByHash"
+    return "eth_getBlockByNumber"
   }
-
+  
   init(_ parameters: Parameters) {
     self.parameters = parameters
   }
 }
+


### PR DESCRIPTION
* Added GetBlockByNumber request
* Fixed bug where an `Unmarshaling` object would not be parsed correctly within the `ValueType` protocol extension.
* Made `Block` members `public`
* Made `Transaction` members `public`
* Ensured we’re stringifying `Hash` param in `GetTransactionByHash` request.