### PR TITLE
Adding usesReplayProtection var for signatures so EtherKit only uses …

### DIFF
--- a/EtherKit/Extensions/String+NumberParsing.swift
+++ b/EtherKit/Extensions/String+NumberParsing.swift
@@ -36,7 +36,7 @@ extension String {
     return bytes
   }
 
-  var hasHexPrefix: Bool {
+  public var hasHexPrefix: Bool {
     return hasPrefix("0x")
   }
 }

--- a/EtherKit/Models/SendTransaction.swift
+++ b/EtherKit/Models/SendTransaction.swift
@@ -61,4 +61,8 @@ extension SendTransaction: Signable {
       from: toRLPValue() + Signature(v: network.rawValue, r: 0.packedData, s: 0.packedData).toRLPValue()
     ).data
   }
+
+  public var usesReplayProtection: Bool {
+    return true
+  }
 }

--- a/EtherKit/Models/TypedData.swift
+++ b/EtherKit/Models/TypedData.swift
@@ -395,4 +395,8 @@ extension TypedData: Signable {
 
     return data.sha3(.keccak256)
   }
+
+  public var usesReplayProtection: Bool {
+    return true
+  }
 }


### PR DESCRIPTION
…the replay protection functionality described in EIP-155 in situations where its supposed to be used