### PR TITLE
Fix Array ABIValueType.

### DIFF
--- a/EtherKit/ABI.swift
+++ b/EtherKit/ABI.swift
@@ -251,7 +251,7 @@ extension Data: ABIValueType {
   }
 }
 
-extension Array: ABIValueType where Element == ABIValueType {
+extension Array: ABIValueType where Element: ABIValueType {
   public var abiType: ABIType {
     if count == 0 {
       fatalError()


### PR DESCRIPTION
This example would not compile:
```swift 
let myArray: [String] = ["string"]
let abiArray: ABIValueType = myArray
```
This change fixes it. 

Marek from Ackee.