### PR TITLE
Fix can't form range.

### DIFF
--- a/EtherKit/ABI.swift
+++ b/EtherKit/ABI.swift
@@ -251,7 +251,7 @@ extension Data: ABIValueType {
   }
 }
 
-extension Array: ABIValueType where Element == ABIValueType {
+extension Array: ABIValueType where Element: ABIValueType {
   public var abiType: ABIType {
     if count == 0 {
       fatalError()


### PR DESCRIPTION
When I did this:
```swift
let totalSupplyFunctionCall = Function(name: "totalSupply", parameters: [])
totalSupplyFunctionCall.encodeToCall()
```
It failed with this error:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/9371695/45619622-3ef7be00-ba7a-11e8-9dc4-326d047cc6e8.png">

This should fix it.